### PR TITLE
Forces CSR1000v to use the MGMT-VRF when copying data through HTTP in transfer_configs_to_nodes.py

### DIFF
--- a/transfer_configs_to_nodes.py
+++ b/transfer_configs_to_nodes.py
@@ -50,6 +50,7 @@ def copy_files_to_node(node):
 
         net_connect = ConnectHandler(**router)
         for filename in os.listdir(f'{user_directory}/lab_configs/{node["name"]}'):
+            net_connect.send_config_set(["ip http client source-interface GigabitEthernet1"])
             net_connect.send_command(f'copy http://{server_ip}:8000/{user_directory}/lab_configs/{node["name"]}/{filename} flash:{filename}',
                 expect_string = 'Destination')
             output = net_connect.send_command(filename, expect_string = r'confirm\]|#')


### PR DESCRIPTION
As the title says. Some versions of Containerlab do not configure on the CSR1000v the source interface for the HTTP client. That is why the transfer of .cfgs files fail if this is not configured on the routers previous to running the script. 
With this modification, the script configures it before attempting to download the .cfg files through HTTP. 